### PR TITLE
Supporto (minimale) per apertura file specifico passato su riga di co…

### DIFF
--- a/Source/uMainform.pas
+++ b/Source/uMainform.pas
@@ -298,6 +298,9 @@ begin
         ComboBoxStile.ItemIndex:=0;
 
     ReadXmlList(dirIn,dirOut);
+
+    if (ParamCount > 0) and SameText(ExtractFileExt(ParamStr(1)), '.xml') then
+      ApriFatturaXML(ParamStr(1));
 end;
 
 procedure TMainform.ReadXmlList(dirIn,dirOut:string);


### PR DESCRIPTION
…mando (abilita associazione con file XML in Explorer per facilitare l'apertura dei file XML con un semplice doppio click)